### PR TITLE
⚡ Bolt: Optimize N+1 queries with @BatchSize

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-01-21 - Environment Java Version Mismatch
+**Learning:** The project is configured for Java 25 (preview features enabled), but the local environment runs Java 21. This mismatch prevents compiling and running the full test suite locally.
+**Action:** When working on this project in this environment, rely on static analysis, careful code review, and adherence to standard patterns. Avoid attempting to run `mvn test` if it requires Java 25 features.

--- a/modulith-product/src/main/java/com/app/product/entities/Category.java
+++ b/modulith-product/src/main/java/com/app/product/entities/Category.java
@@ -2,6 +2,7 @@ package com.app.product.entities;
 
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -29,6 +30,7 @@ public class Category {
 	@Size(min = 5, message = "Category name must contain atleast 5 characters")
 	private String categoryName;
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
 	private List<Product> products;
 }

--- a/modulith-product/src/main/java/com/app/product/entities/Product.java
+++ b/modulith-product/src/main/java/com/app/product/entities/Product.java
@@ -2,6 +2,7 @@ package com.app.product.entities;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.annotations.BatchSize;
 import com.app.review.entities.ProductReview;
 import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
@@ -54,12 +55,15 @@ public class Product extends ExtensibleEntity {
 	@JoinColumn(name = "category_id")
 	private Category category;
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProductVariant> variants = new ArrayList<>();
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProductMedia> media = new ArrayList<>();
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProductReview> reviews = new ArrayList<>();
 
@@ -74,9 +78,11 @@ public class Product extends ExtensibleEntity {
 
 	private boolean isBundle = false;
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "bundleProduct", cascade = CascadeType.ALL)
 	private List<BundleItem> bundleItems = new ArrayList<>();
 
+	@BatchSize(size = 20)
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
 	private List<ProductPriceList> priceLists = new ArrayList<>();
 


### PR DESCRIPTION
💡 What: Added `@BatchSize(size = 20)` to `@OneToMany` collections in `Product.java` and `Category.java`.
🎯 Why: Mitigates the N+1 select problem when fetching lists of products or categories and accessing their related lazy-loaded collections (variants, media, reviews, products).
📊 Impact: Reduces database roundtrips significantly (e.g., from 1+N queries to 1+1 queries per collection access for a batch of 20 entities).
🔬 Measurement: Verified static correctness and standard Hibernate optimization pattern.

---
*PR created automatically by Jules for task [913429641053739258](https://jules.google.com/task/913429641053739258) started by @i-vasu*