### PR TITLE
⚡ Bolt: Add @BatchSize to fix N+1 queries in Product/Category

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-01-28 - Java Version Mismatch in CI/CD vs Project
+**Learning:** The project is configured for Java 25 (`pom.xml`), but the execution environment runs Java 21. This mismatch prevents running `mvn compile` or `mvn test` locally without modifying the build configuration (which is restricted).
+**Action:** In this environment, prioritize static analysis, visual code verification, and "safe" pattern-based optimizations (like standard Hibernate annotations) over reliance on local test execution. Document this constraint clearly.

--- a/modulith-product/src/main/java/com/app/product/entities/Category.java
+++ b/modulith-product/src/main/java/com/app/product/entities/Category.java
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.hibernate.annotations.BatchSize;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -30,5 +31,6 @@ public class Category {
 	private String categoryName;
 
 	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+	@BatchSize(size = 20)
 	private List<Product> products;
 }

--- a/modulith-product/src/main/java/com/app/product/entities/Product.java
+++ b/modulith-product/src/main/java/com/app/product/entities/Product.java
@@ -3,6 +3,7 @@ package com.app.product.entities;
 import java.util.ArrayList;
 import java.util.List;
 import com.app.review.entities.ProductReview;
+import org.hibernate.annotations.BatchSize;
 import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -22,8 +23,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.app.core.persistence.ExtensibleEntity;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "products")
@@ -55,12 +54,15 @@ public class Product extends ExtensibleEntity {
 	private Category category;
 
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 20)
 	private List<ProductVariant> variants = new ArrayList<>();
 
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 20)
 	private List<ProductMedia> media = new ArrayList<>();
 
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 20)
 	private List<ProductReview> reviews = new ArrayList<>();
 
 	private boolean isCustomizable = false;
@@ -75,9 +77,11 @@ public class Product extends ExtensibleEntity {
 	private boolean isBundle = false;
 
 	@OneToMany(mappedBy = "bundleProduct", cascade = CascadeType.ALL)
+	@BatchSize(size = 20)
 	private List<BundleItem> bundleItems = new ArrayList<>();
 
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+	@BatchSize(size = 20)
 	private List<ProductPriceList> priceLists = new ArrayList<>();
 
 	public Product() {


### PR DESCRIPTION
⚡ Bolt: Implement Batch Fetching for Product Collections

💡 What:
Added `@BatchSize(size = 20)` annotation to `Product` (variants, media, reviews, bundleItems, priceLists) and `Category` (products) entities.

🎯 Why:
To solve the N+1 Selects problem. When fetching a list of products (e.g., via `getAllProducts`), Hibernate typically executes one query for the products and then separate queries for each product's related collections when they are accessed (e.g., during DTO mapping). This leads to O(N) queries.

📊 Impact:
Reduces the number of database round-trips significantly. For a default page size of 20 products, queries for related collections (like variants) are reduced from 20 to 1. Total query count for a fully mapped product page could drop from ~61 to ~4.

🔬 Measurement:
Verified via code inspection and standard Hibernate behavior guarantees. Local execution restricted by Java version mismatch (Project Java 25 vs Env Java 21), documented in `.jules/bolt.md`.


---
*PR created automatically by Jules for task [8427036006886593932](https://jules.google.com/task/8427036006886593932) started by @i-vasu*